### PR TITLE
BUGFIX: handle quoted arguments properly

### DIFF
--- a/git-spread
+++ b/git-spread
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-COMMAND=$@
-
 if [ $# == 0 ]; then
   echo "usage: git spread <normal git commands>"
   echo "  Use git-spread to run git commands across directories"
@@ -14,13 +12,14 @@ fi
 # set command defaults
 if [ $# == 1 ]; then
   if [ $1 == 'status' ]; then
-    COMMAND='status -s'
+			$0 status -s
+			exit
   fi
 fi
 
 for i in */;
 do
   if [ -e $i/.git ]; then
-    (cd $i && echo "$i: git $COMMAND" && git $COMMAND && echo)
+			(cd $i && echo "$i: git $@" && git "$@" && echo)
   fi
 done


### PR DESCRIPTION
Altered script to leverage bash hack of `"$@"` to get quoted versions of arguments. Changed "status" -> "status -s" to operate by recursive execution.